### PR TITLE
minor enhancements/fixes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -245,7 +245,7 @@ fun determineVersion(): String {
         "$latestVersion-$diff-g${currentCommit.substring(0, 7)}"
     }
     return if (command("git", "status", "--porcelain").any { it.isNotEmpty() }) {
-        "$version*"
+        "$version#"
     } else {
         version
     }

--- a/src/api/kotlin/de/johni0702/minecraft/betterportals/common/block/PortalBlock.kt
+++ b/src/api/kotlin/de/johni0702/minecraft/betterportals/common/block/PortalBlock.kt
@@ -165,7 +165,7 @@ interface PortalBlock<EntityType> where EntityType: Entity, EntityType: Linkable
                         .coerceIn(-29999872, 29999872)
         )
 
-        val searchDist = 64
+        val searchDist = 128
         val remotePos0 = remotePosition.add(0, -remotePosition.y, 0)
         val remoteChunkPos = ChunkPos(remotePos0)
 


### PR DESCRIPTION
I don't know if its intended, but the vanilla search distance of an existing portal has a radius of 128 blocks.